### PR TITLE
Adding delete endpoint for patients and vcf files

### DIFF
--- a/app/controllers/api/patients_controller.rb
+++ b/app/controllers/api/patients_controller.rb
@@ -14,8 +14,10 @@ class Api::PatientsController < Api::BaseController
     p = Patient.find_by_case_id(patient_id)
     if !p.nil?
       respond_to do |format|
-        format.json { render plain: { msg: 'DPDL case already exists' }.to_json, status: 400,
-                      content_type: 'application/json' }
+        format.json { render plain: { msg: 'DPDL case already exists' }.to_json,
+                      status: 400,
+                      content_type: 'application/json'
+                    }
       end
       return
     end
@@ -95,10 +97,14 @@ class Api::PatientsController < Api::BaseController
     respond_to do |format|
       if patient.save
         format.json { render plain: { msg: 'DPDL case created successfully' }.to_json,
-                      status: 200, content_type: 'application/json' }
+                      status: 200,
+                      content_type: 'application/json'
+                    }
       else
         format.json { render plain: { error: 'Unable to save patient information. Please check the data'}.to_json,
-                      status: 400, content_type: 'application/json' }
+                      status: 400,
+                      content_type: 'application/json'
+                    }
       end
     end
   end
@@ -122,7 +128,9 @@ class Api::PatientsController < Api::BaseController
     if p.nil?
       respond_to do |format|
         format.json { render plain: { msg: 'Case does not exist. Please create a case first to get PEDIA results' }.to_json,
-                      status: 400, content_type: 'application/json' }
+                      status: 400,
+                      content_type: 'application/json'
+                    }
       end
       return
     end
@@ -134,7 +142,9 @@ class Api::PatientsController < Api::BaseController
     if !(File.exist?(result_file_name))
       respond_to do |format|
         format.json { render plain: { error: 'Results are not available yet, please check later'}.to_json,
-                      status: 404, content_type: 'application/json' }
+                      status: 404,
+                      content_type: 'application/json'
+                    }
       end
       return
     end
@@ -159,32 +169,32 @@ class Api::PatientsController < Api::BaseController
   #DELETE /patients/id
   def destroy
     case_id = params[:id]
-
     p = Patient.find_by_case_id(case_id)
     if p.nil?
       respond_to do |format|
-        format.json { render plain: {msg: 'case does not exist' }.to_json, status: 400,
-                      content_type: 'application/json' }
+        format.json { render plain: { msg: 'case does not exist' }.to_json,
+                      status: 400,
+                      content_type: 'application/json'
+                    }
       end
       return
     else
       path_json_file = "#{Rails.root}/Data/Received_JsonFiles/#{case_id}.json"
       File.delete(path_json_file) if File.exist?(path_json_file)
       p.destroy
-
       vcf = UploadedVcfFile.find_by_case_id(case_id)
       if !vcf.nil?
         path_vcf_file = "#{Rails.root}/Data/Received_VcfFiles/#{vcf.file_name}"
         File.delete(path_vcf_file) if File.exist?(path_vcf_file)
         vcf.destroy
       end
-
       respond_to do |format|
-        format.json { render plain: {msg: 'Patient information deleted' }.to_json,
-                      status: 200, content_type: 'application/json' }
+        format.json { render plain: { msg: 'Patient information deleted' }.to_json,
+                      status: 200,
+                      content_type: 'application/json'
+                    }
       end
     end
-
   end
 
   def authenticate_token
@@ -195,13 +205,17 @@ class Api::PatientsController < Api::BaseController
     else
       if token.expired?
         respond_to do |format|
-          format.json { render plain: { error: 'Token expired' }.to_json, status: 401,
-                        content_type: 'application/json' }
+          format.json { render plain: { error: 'Token expired' }.to_json,
+                        status: 401,
+                        content_type: 'application/json'
+                      }
         end
       else
         respond_to do |format|
-          format.json { render plain: { error: 'Invalid token' }.to_json, status: 401,
-                        content_type: 'application/json' }
+          format.json { render plain: { error: 'Invalid token' }.to_json,
+                        status: 401,
+                        content_type: 'application/json'
+                      }
         end
       end
     end

--- a/app/controllers/api/vcf_files_controller.rb
+++ b/app/controllers/api/vcf_files_controller.rb
@@ -20,7 +20,7 @@ class Api::VcfFilesController < Api::BaseController
     if p.nil?
       respond_to do |format|
         format.json { render plain: { msg: 'Corresponding case does not exist. Please create the case first' }.to_json,
-		              status: 400, content_type: 'application/json' }
+                      status: 400, content_type: 'application/json' }
       end
       return
     end
@@ -48,7 +48,7 @@ class Api::VcfFilesController < Api::BaseController
 
     respond_to do |format|
       format.json { render plain: {msg: 'VCF file uploaded successfully. PEDIA workflow will be triggered' }.to_json,
-	                status: 200, content_type: 'application/json' }
+                    status: 200, content_type: 'application/json' }
     end
   end
 
@@ -65,6 +65,26 @@ class Api::VcfFilesController < Api::BaseController
     end
 
     return valid
+  end
+
+  # DELETE /vcf_files/id
+  def destroy
+    case_id = params[:id]
+    vcf = UploadedVcfFile.find_by_case_id(case_id)
+    if !vcf.nil?
+      vcf.destroy
+      path_vcf_file = "#{Rails.root}/Data/Received_VcfFiles/#{vcf.file_name}"
+      File.delete(path_vcf_file) if File.exist?(path_vcf_file)
+      respond_to do |format|
+        format.json { render plain: {msg: 'Vcf file deleted' }.to_json,
+                      status: 200, content_type: 'application/json' }
+      end
+    else
+      respond_to do |format|
+        format.json { render plain: {msg: 'File does not exist' }.to_json,
+                      status: 400, content_type: 'application/json' }
+      end
+    end
   end
 
   def authenticate_token

--- a/app/controllers/api/vcf_files_controller.rb
+++ b/app/controllers/api/vcf_files_controller.rb
@@ -7,7 +7,10 @@ class Api::VcfFilesController < Api::BaseController
     # validate file extension and that the file belongs to the correponding case_id
     if not validate_filename
       respond_to do |format|
-        format.json { render plain: { msg: 'Invalid file' }.to_json, status: 400, content_type: 'application/json' }
+        format.json { render plain: { msg: 'Invalid file' }.to_json,
+                      status: 400,
+                      content_type: 'application/json'
+                    }
       end
       return
     end
@@ -20,7 +23,9 @@ class Api::VcfFilesController < Api::BaseController
     if p.nil?
       respond_to do |format|
         format.json { render plain: { msg: 'Corresponding case does not exist. Please create the case first' }.to_json,
-                      status: 400, content_type: 'application/json' }
+                      status: 400,
+                      content_type: 'application/json'
+                    }
       end
       return
     end
@@ -47,8 +52,10 @@ class Api::VcfFilesController < Api::BaseController
     PediaServiceJob.perform_later(service)
 
     respond_to do |format|
-      format.json { render plain: {msg: 'VCF file uploaded successfully. PEDIA workflow will be triggered' }.to_json,
-                    status: 200, content_type: 'application/json' }
+      format.json { render plain: { msg: 'VCF file uploaded successfully. PEDIA workflow will be triggered' }.to_json,
+                    status: 200,
+                    content_type: 'application/json'
+                  }
     end
   end
 
@@ -76,13 +83,17 @@ class Api::VcfFilesController < Api::BaseController
       path_vcf_file = "#{Rails.root}/Data/Received_VcfFiles/#{vcf.file_name}"
       File.delete(path_vcf_file) if File.exist?(path_vcf_file)
       respond_to do |format|
-        format.json { render plain: {msg: 'Vcf file deleted' }.to_json,
-                      status: 200, content_type: 'application/json' }
+        format.json { render plain: { msg: 'Vcf file deleted' }.to_json,
+                      status: 200,
+                      content_type: 'application/json'
+                    }
       end
     else
       respond_to do |format|
-        format.json { render plain: {msg: 'File does not exist' }.to_json,
-                      status: 400, content_type: 'application/json' }
+        format.json { render plain: { msg: 'File does not exist' }.to_json,
+                      status: 400,
+                      content_type: 'application/json'
+                    }
       end
     end
   end
@@ -95,11 +106,17 @@ class Api::VcfFilesController < Api::BaseController
     else
       if token.expired?
         respond_to do |format|
-          format.json { render plain: {error: 'Token expired' }.to_json, status: 401, content_type: 'application/json' }
+          format.json { render plain: { error: 'Token expired' }.to_json,
+                        status: 401,
+                        content_type: 'application/json'
+                      }
         end
       else
         respond_to do |format|
-          format.json { render plain: {error: 'Invalid token' }.to_json, status: 401, content_type: 'application/json' }
+          format.json { render plain: { error: 'Invalid token' }.to_json,
+                        status: 401,
+                        content_type: 'application/json'
+                      }
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,9 +32,9 @@ Rails.application.routes.draw do
   post '/annotations/new' => 'annotations#new', as: :annotations_new 
 
   namespace :api do
-    resources :patients, only: [:create]
+    resources :patients, only: [:create, :destroy]
     resources :auth ,only: [:create]
-    resources :vcf_files, only: [:create]
+    resources :vcf_files, only: [:create, :destroy]
     get '/get_results/' => 'patients#get_results'
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
opening destroy endpoint for patients and vcf files, adding corresponding functions in the controllers.

Testing delete functionality:
1) Url request to delete patients: type of req: DELETE
DELETE /api/patients/id
authorization header: valid token
eg: DELETE http://172.30.1.29:3000/api/patients/5

If the patient exists, then deletes the record, otherwise, 400 msg is sent
Delete patient will delete the JSON file, record form patient table and any corresponding record from patients_features. Also will delete the corresponding Vcf file uploaded(if any)

2)Url request for delete vcf_file: req type : DELETE
DELETE /api/vcf_files/id
authorization header: valid token
eg: DELETE http://172.30.1.29:3000/api/vcf_files/6

If vcf file exists, then deletes the file, otherwise, 400 msg is sent
Delete vcf_file will delete the uploaded vcf file and corresponding entry from the uploaded_vcffile table.