### PR TITLE
Update PEDIA workflow and documents

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,108 +1,85 @@
 configfile: "config.yaml"
 
+# PEDIA home directory
 PEDIA_DIR = config['PEDIA_PATH']
+
+# DPDL vcf and json directory
+RECEIVED_VCF_DIR = "Data/Received_VcfFiles"
+RECEIVED_JSON_DIR = "Data/Received_JsonFiles"
+
+# input directory for PEDIA analysis
+# cp json file to process/dpdl/{case_id}/case
+# cp vcf file to process/dpdl/{case_id}/vcfs
+PEDIA_PROCESS_DIR = os.path.join(PEDIA_DIR, "process/dpdl")
+PEDIA_PHENO_DIR = os.path.join(PEDIA_DIR, "data/PEDIA/jsons/phenomized")
+PEDIA_VCF_DIR = os.path.join(PEDIA_DIR, "data/PEDIA/vcfs/original")
 
 subworkflow classifier_workflow:
 	workdir: PEDIA_DIR + "classifier/scripts"
 	snakefile: PEDIA_DIR + "classifier/Snakefile"
 
-rule cp_json:
-	input: 
-		json = "Data/Received_JsonFiles/" + "{case}.json"
-	output:
-		json = PEDIA_DIR + "lab/" + "{case}.json"
-	shell:
-		"""
-		cp {input.json} {output.json}
-		"""
+def get_process_vcf(wc):
+	configfile: "Data/Received_JsonFiles/%s.json" % wc.case
+	docs = config['documents']
+	for doc in docs:
+		if doc['is_vcf']:
+			filename = doc['document_name']
+	return filename
 
-rule compress_vcf:
-	input: 
-		vcf = "Data/Received_VcfFiles/" + "{case}.vcf"
+rule convert:
+	input:
+		json = os.path.join(RECEIVED_JSON_DIR, "{case}.json")
 	output:
-		vcf = "Data/Received_VcfFiles/" + "{case}.vcf.gz"
-	shell:
-		"""
-		bgzip -c {input.vcf} > {output.vcf}
-		"""
-
-rule cp_vcf:
-	input: 
-		vcf = "Data/Received_VcfFiles/" + "{case}.vcf.gz"
-	output:
-		vcf = PEDIA_DIR + "data/PEDIA/vcfs/original/" + "{case}.vcf.gz"
-	shell:
-		"""
-		cp {input.vcf} {output.vcf}
-		"""
-
-rule per:
-	input: 
-		json = PEDIA_DIR + "lab/" + "{case}.json"
-	output:
-		json = PEDIA_DIR + "out/" + "{case}.json"
+		json = os.path.join(PEDIA_PROCESS_DIR, "{case}.json")
 	params:
-		dir = PEDIA_DIR + "out/",
+		dir = os.path.join(PEDIA_PROCESS_DIR),
 		script = PEDIA_DIR + "convert.py",
 		omim = PEDIA_DIR + "preproc/216_gestalt_syn_to_omim_final.csv"
 	shell:
 		"""
-		python {params.script} -c {input.json} -o {params.dir} -m {params.omim} 
+		mkdir -p {params.dir}
+		python {params.script} -c {input.json} -o {params.dir} -m {params.omim}
 		"""
 
-rule convert:
-	input: 
-		json = PEDIA_DIR + "out/" + "{case}.json"
+rule phenomize:
+	input:
+		json = os.path.join(PEDIA_PROCESS_DIR, "{case}.json"),
+		vcf = get_process_vcf
 	output:
-		json = PEDIA_DIR + "data/PEDIA/jsons/phenomized/" + "{case}.json"
+		json = os.path.join(PEDIA_PHENO_DIR, "{case}.json")
 	params:
-		dir = PEDIA_DIR + "data/PEDIA/jsons/phenomized/",
-		script = PEDIA_DIR + "preprocess.py",
+		dir = PEDIA_PHENO_DIR,
+		script = os.path.join(PEDIA_DIR, "preprocess.py"),
 		work_dir = PEDIA_DIR
 	shell:
 		"""
-		cd {params.work_dir} 
+		cd {params.work_dir}
 		python {params.script} -s {input.json} -o {params.dir}
 		"""
 
-rule pre_json_vcf:
-	input: 
-		json = PEDIA_DIR + "data/PEDIA/jsons/phenomized/" + "{case}.json",
-		vcf = PEDIA_DIR + "data/PEDIA/vcfs/original/" + "{case}.vcf.gz",
+rule preprocess:
+	input:
+		json = os.path.join(PEDIA_PHENO_DIR, "{case}.json")
 	output:
-		"Data/PEDIA_service/{case}/" + "{case}_preproc.done"
+		"Data/PEDIA_service/{case}/preproc.done"
 	params:
 		dir = "Data/PEDIA_service/{case}/"
 	shell:
 		"""
-		mkdir -p {params.dir} 
+		mkdir -p {params.dir}
 		touch {output}
 		"""
 
 rule pedia:
-	input: 
-		json = PEDIA_DIR + "data/PEDIA/jsons/phenomized/" + "{case}.json",
-		vcf = PEDIA_DIR + "data/PEDIA/vcfs/original/" + "{case}.vcf.gz",
+	input:
 		out = classifier_workflow("../output/test/1KG/{case}/run.out")
 	output:
-		result = "Data/PEDIA_service/{case}/" + "{case}.csv"
+		result = "Data/PEDIA_service/{case}/{case}.csv"
 	params:
 		dir = "Data/PEDIA_service/{case}/",
-		result = PEDIA_DIR + "classifier/output/test/1KG/{case}/" + "{case}.csv"
+		result = PEDIA_DIR + "classifier/output/test/1KG/{case}/{case}.csv"
 	shell:
 		"""
-		mkdir -p {params.dir} 
+		mkdir -p {params.dir}
 		cp {params.result} {output.result}
-		"""
-
-rule cp_result:
-	input: 
-		json = classifier_workflow("../output/test/1KG/{case}/run.out")
-	output:
-		json = "Data/PEDIA_service/{case}/" + "{case}.json"
-	params:
-		dir = "Data/PEDIA_service/{case}/"
-	shell:
-		"""
-		cp {input.json} {output.json}
 		"""

--- a/app/controllers/api/patients_controller.rb
+++ b/app/controllers/api/patients_controller.rb
@@ -184,7 +184,7 @@ class Api::PatientsController < Api::BaseController
       p.destroy
       vcf = UploadedVcfFile.find_by_case_id(case_id)
       if !vcf.nil?
-        path_vcf_file = "#{Rails.root}/Data/Received_VcfFiles/#{vcf.file_name}"
+        path_vcf_file = "#{Rails.root}/Data/Received_VcfFiles/#{case_id}/#{vcf.file_name}"
         File.delete(path_vcf_file) if File.exist?(path_vcf_file)
         vcf.destroy
       end

--- a/app/models/pedia_service.rb
+++ b/app/models/pedia_service.rb
@@ -17,7 +17,7 @@ class PediaService < ApplicationRecord
     end
     service_path = 'Data/PEDIA_service/'
 
-    done_file = File.join(service_path, case_id, case_id + '_preproc.done')
+    done_file = File.join(service_path, case_id, 'preproc.done')
     cmd = ['.', activate_path, 'pedia;', snakemake_path, done_file].join ' '
     log_path = File.join("#{Rails.root}", 'log', 'pedia', case_id)
     unless File.directory?(log_path)
@@ -27,6 +27,9 @@ class PediaService < ApplicationRecord
     # Run preprocessing to generate phenomized json
     # Todo:
     # connect following two preocess into one
+    # First cmd is:
+    # . activate pedia; snakemake --nolock
+    # Data/PEDIA_service/case_id/preproc.done
     out_log = File.join(log_path, case_id + '_pre.out')
     logger = Logger.new(out_log)
     Open3.popen3(cmd) do |stdin, stdout, stderr, thread|
@@ -34,7 +37,7 @@ class PediaService < ApplicationRecord
       { out: stdout, err: stderr }.each do |key, stream|
         Thread.new do
           until (raw_line = stream.gets).nil? do
-            logger.info("#{raw_line}")
+            logger.info("#{raw_line.delete!("\n")}")
           end
         end
       end
@@ -51,7 +54,7 @@ class PediaService < ApplicationRecord
       { out: stdout, err: stderr }.each do |key, stream|
         Thread.new do
           until (raw_line = stream.gets).nil? do
-            logger.info("#{raw_line}")
+            logger.info("#{raw_line.delete!("\n")}")
           end
         end
       end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -98,6 +98,9 @@
             <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <%= current_user.email %>
+              <% if true_user.admin? and true_user != current_user %>
+                <%= link_to 'Stop impersonating', stop_impersonating_users_path, method: :post, data: { confirm: 'Switch back to your account?' } %>
+              <% end %>
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
               <%= link_to 'Edit profile', edit_user_registration_path, :class => 'dropdown-item' %>

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,6 +1,6 @@
 Delayed::Worker.destroy_failed_jobs = false
-Delayed::Worker.sleep_delay = 20
-Delayed::Worker.max_attempts = 3
+Delayed::Worker.sleep_delay = 10
+Delayed::Worker.max_attempts = 2
 Delayed::Worker.max_run_time = 60.minutes
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'

--- a/docs/PEDIA.md
+++ b/docs/PEDIA.md
@@ -1,0 +1,1 @@
+# This file is for running PEDIA pipeline

--- a/docs/PEDIA.md
+++ b/docs/PEDIA.md
@@ -1,1 +1,110 @@
-# This file is for running PEDIA pipeline
+# Running PEDIA pipeline
+## Setup
+### DPDL
+ * config.yaml for setup path to PEDIA pipeline
+ ```
+ # In config.yaml tell DPDL where PEDIA is in your system
+ PEDIA_PATH: '/data/project/pedia3/PEDIA-workflow/'
+ ```
+### PEDIA
+1. Clone PEDIA workflow and checkout dpdl branch, and clone submodule classifier.
+   ```
+   git clone https://github.com/PEDIA-Charite/PEDIA-workflow.git
+   git checkout dpdl
+   git submodule update --recursive
+   ```
+
+1. Copy config file from the PEDIA folder in sciebo
+   * config.ini 
+   * hgvs_errors.json
+ 
+1. Setup environment
+   * install miniconda
+   * install pedia environment
+   ```
+   # create pedia environment
+   conda env create -f environment.yaml
+ 
+   # activate pedia environment
+   source activate pedia
+ 
+   # deactivate pedia environment
+   source deactivate
+   ```
+4. Download all necessary files
+   ```
+   # Download all files by running snakemake in data folder
+   # It may takes several hours. You can also and --cores 4
+   # to run with 4 threads.
+   source activate pedia
+   cd data
+   snakemake -p all
+   ```
+5. Download training json file to training folder
+   * To save your time for preprocess all training data, use the json files from
+   our project folder in sciebo.
+   Extract CV.tar.gz and put all files in 3_simulation/jsons/1KG/CV/.
+
+## Run DPDL and PEDIA
+### activate delayed_job workers
+   * We used delayed_job to manage all submission from F2G. The jobs will be sent to a queue. Then we have to activate workers to process the jobs in the queue.
+   ```
+   # Run one worker
+   bin/delayed_job start
+   # Run two workers
+   bin/delayed_job -n 2 start
+   ```
+### create patient
+   ```
+   http://localhost:3000/api/patients
+   ```
+### send VCF file
+   * the PEDIA pipeline will be triggered once we received VCF file.
+   * VCF file is saved in Data/Received_VcfFiles/case_id/.
+   * Before activate PEDIA pipeline, we will add the following data to patient JSON file
+   to point the path to VCF file
+   ```
+   "documents": [
+        {
+            "document_name": "/home/la60312/project/dpdl/Data/Received_VcfFiles/12/12.vcf",
+            "is_vcf": 1
+        }
+    ]
+   ```
+### Trigger PEDIA pipeline
+Triggering PEDIA is mainly in app/models/pedia_service.rb and Snakefile. There are two steps for PEDIA
+preprocessing and main workflow. For these two steps, we call two shell commands in pedia_service.rb to
+trigger the rules in Snakefile.
+
+**Note**:
+
+We haven't block the new submission of same case while the previous one is still running because we use 
+snakemake --nolock here. For example, if case 12345 is still running, we can't send 12345 again before 
+the process is completed.
+
+1. Preprocessing
+   * The pedia_service.rb call the following function for the following purposes. All the rules are defined
+   in Snakefile
+   * convert JSON format to PEDIA JSON format. The new JSON file will be in
+   process/dpdl/12345.json (in PEDIA folder)
+   * phenomize and convert syndrome to genes. The phenomized JSON file will be in 
+   data/PEDIA/jsons/phenomized/12345.json
+   * copy and compress VCF file to data/PEDIA/vcfs/original/12345.vcf.gz (in PEDIA folder)
+   ```
+   snakemake --nolock Data/PEDIA_service/12345/preproc.done
+   # log file in log/pedia/12345/12345_pre.out
+   ```
+   
+1. PEDIA main workflow
+   * annotating VCF file in the VCF workflow in data/PEDIA/vcfs/. All the rules are defined in
+   data/PEDIA/vcfs/Snakefile. The annotated VCF is in data/PEDIA/vcfs/annotated_vcfs/
+   * extract CADD from VCF file and append to JSON file. All the rules are defined in
+   3_simulation/Snakefile. The final JSON file is in 3_simulation/jsons/real/unknown_test/12345.json
+   * classification. Classifier will be trained by the JSON files in 3_simulation/jsons/1KG/CV, and
+   further classify 3_simulation/jsons/real/unknown_test/12345.json. The results are in 
+   classifier/output/test/12345/.
+   * Copy the classifier/output/test/12345/12345.csv back to Data/PEDIA_service/12345/12345.csv
+   ```
+   snakemake --nolock Data/PEDIA_service/12345/12345.csv
+   # log file in log/pedia/12345/12345.out
+   ```


### PR DESCRIPTION
We moved VCF files to Received_VcfFiles/case_id/ to support different
naming.
Moreover, we avoid to rerun annotation if the VCF file is identical.