### PR TITLE
User group feature

### DIFF
--- a/app/assets/javascripts/groups.coffee
+++ b/app/assets/javascripts/groups.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the group controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,123 @@
+class GroupsController < ApplicationController
+  before_action :check_access
+  before_action :set_group, only: [:show, :edit, :update, :destroy]
+  after_action :assign_group_patients ,only: [:create, :update]
+
+  def index
+    @groups = Group.order(:id).page(params[:page]).per(25)
+  end
+
+  # PATCH/PUT /groups/1
+  def update
+    new_grp_name = params[:group]['name']
+    new_members = params[:users]
+    remove_members = params[:members]
+
+    ActiveRecord::Base.transaction do
+      @group.name = new_grp_name
+      if new_members
+        new_members.each do |m|
+          user = User.where(id:m).first
+          Member.create(user_id: user.id, group_id: @group.id)
+        end
+      end
+
+      if remove_members
+        remove_members.each do |mem|
+          user = User.where(id:mem).first
+          Member.where(user_id: user.id).where(group_id: @group.id).destroy_all
+          email = user.email
+          submitter = Submitter.find_by_email(email)
+          if submitter != nil
+            submitter.patient.each do |patient|
+              @group.patients.destroy_all
+            end
+          end
+        end
+      end
+    end
+    respond_to do |format|
+      if @group.save
+        format.html { redirect_to @group, notice: 'Group was Updated successfully' }
+      else
+        format.html { render :new }
+        format.json { render json: @group.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # GET /groups/new
+  def new
+    @groups = Group.new
+    @users = User.all
+  end
+
+  def create
+    grp_name = params[:name]
+    members = params[:users]
+    puts members
+    ActiveRecord::Base.transaction do
+      @group = Group.create(name: grp_name)
+      members.each do |m|
+        user = User.where(id:m).first
+        Member.create(user_id: user.id, group_id: @group.id)
+      end
+    end
+    respond_to do |format|
+      if @group.save
+        format.html { redirect_to @group, notice: 'Group was successfully created' }
+
+      else
+        format.html { render :new }
+        format.json { render json: @group.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def show
+
+  end
+
+    # GET /patients/1/edit
+  def edit
+    @users = User.all
+    @members = @group.users
+  end
+
+
+  def destroy
+    @group.destroy
+    respond_to do |format|
+      format.html { redirect_to groups_url, notice: 'Group was successfully destroyed' }
+      format.json { head :no_content }
+    end
+  end
+
+
+  private
+
+  def set_group
+    @group = Group.find(params[:id])
+  end
+
+
+  def check_access
+   (current_user.nil?) ? redirect_to(root_path) : (redirect_to(root_path) unless current_user.admin?)
+  end
+
+  def assign_group_patients
+    # This automatically creates the grouppatient record for each user in the group
+    user = @group.users
+    user.each do |u|
+      email = u.email
+      submitter = Submitter.find_by_email(email)
+      if submitter != nil
+        submitter.patient.each do |patient|
+          if not @group.patients.exists?(patient.id)
+            @group.patients << patient
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -20,8 +20,6 @@ class PatientsController < ApplicationController
         else
           @patients = user.patients.where(result: true).order(:case_id)
         end
-        @patients = @patients.uniq
-        @patients = Kaminari.paginate_array(@patients).page(params[:page]).per(25)
       else
         if not group.empty?
           group.each do |g|
@@ -30,9 +28,9 @@ class PatientsController < ApplicationController
         else
           @patients = user.patients.order(:case_id)
         end
-        @patients = @patients.uniq
-        @patients = Kaminari.paginate_array(@patients).page(params[:page]).per(25)
       end
+      @patients = @patients.uniq
+      @patients = Kaminari.paginate_array(@patients).page(params[:page]).per(25)
     else
       if params[:result] == "true"
         @patients = Patient.where(result: true).order(:case_id).page(params[:page]).per(25)

--- a/app/helpers/group_helper.rb
+++ b/app/helpers/group_helper.rb
@@ -1,0 +1,2 @@
+module GroupHelper
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,7 @@
+class Group < ActiveRecord::Base
+  # destroy the relationship if group is deleted
+  has_many :members, :dependent => :destroy
+  has_many :users, :through => :members
+  has_many :groups_patients, :dependent => :destroy
+  has_many :patients, :through => :groups_patients
+ end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,5 @@ class Group < ActiveRecord::Base
   has_many :users, :through => :members
   has_many :groups_patients, :dependent => :destroy
   has_many :patients, :through => :groups_patients
- end
+end
+ 

--- a/app/models/groups_patient.rb
+++ b/app/models/groups_patient.rb
@@ -1,0 +1,4 @@
+class GroupsPatient < ApplicationRecord
+  belongs_to :group, :optional => true
+  belongs_to :patient, :optional => true
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,0 +1,8 @@
+class Member < ActiveRecord::Base
+   belongs_to :group
+   belongs_to :user
+
+   validates :user_id, :presence => true
+   validates :group_id, :presence => true
+   validates :user_id, :uniqueness => {:scope => [:user_id, :group_id]}
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,8 +1,8 @@
 class Member < ActiveRecord::Base
-   belongs_to :group
-   belongs_to :user
+  belongs_to :group
+  belongs_to :user
 
-   validates :user_id, :presence => true
-   validates :group_id, :presence => true
-   validates :user_id, :uniqueness => {:scope => [:user_id, :group_id]}
+  validates :user_id, :presence => true
+  validates :group_id, :presence => true
+  validates :user_id, :uniqueness => { :scope => [:user_id, :group_id] }
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -14,6 +14,8 @@ class Patient < ApplicationRecord
   has_many :usi_materialnrs, :dependent => :destroy
   has_many :users_patients
   has_many :users, :through => :users_patients
+  has_many :groups_patients
+  has_many :groups, :through => :groups_patients
   validates :case_id, :submitter_id, presence: true
   validates :case_id, uniqueness: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   has_many :vcf_files
   has_many :users_patients
   has_many :patients, :through => :users_patients
+  has_many :members
+  has_many :groups, :through => :members
   has_many :annotations
   after_create :send_admin_mail
   validates :institute, :presence => true
@@ -22,23 +24,23 @@ class User < ApplicationRecord
   validate :validate_username
   after_create :assign_default_patients
 
- 
+
   def validate_username
     if User.where(email: username).exists?
       errors.add(:username, :invalid)
     end
   end
 
-  def active_for_authentication? 
-    super && approved? 
-  end 
+  def active_for_authentication?
+    super && approved?
+  end
 
-  def inactive_message 
-    if !approved? 
-      :not_approved 
-    else 
-      super # Use whatever other message 
-    end 
+  def inactive_message
+    if !approved?
+      :not_approved
+    else
+      super # Use whatever other message
+    end
   end
 
   def send_admin_mail
@@ -60,7 +62,7 @@ class User < ApplicationRecord
   end
 
   private
- 
+
   def assign_default_patients
     # This automatically creates the UserGroup record
     email = self.email

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,0 +1,33 @@
+<%= form_with(model: group, local: true) do |form| %>
+  <% if group.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(group.errors.count, "error") %> prohibited this group from being saved:</h2>
+      <ul>
+        <% group.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :name %>
+    <%= form.text_field :name, id: :group_name %>
+  </div>
+
+  <div class="field">
+    <%= label_tag :"Add Users " %>
+    <%= select_tag "users[]", options_for_select(@users.collect{|x| [x.username, x.id]}), {:multiple => :multiple}  %>
+  </div>
+
+  <div class="field">
+    <%= label_tag :"Remove Users " %>
+    <%= select_tag "members[]", options_for_select(@members.collect{|x| [x.username, x.id]}), {:multiple => :multiple} %>
+  </div>
+  <br/>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+
+<% end %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,0 +1,20 @@
+<h1>Editing Group</h1>
+<%= form_tag group_path(@group) do %>
+  <% if @group.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@group.errors.count, "error") %> prohibited this group from being saved:</h2>
+      <ul>
+        <% @group.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <br><br>
+  <h3>Update group data</h3>
+  <%= render 'form', group: @group %>
+<% end %>
+
+<%= link_to 'Show', @group %> |
+<%= link_to 'Back', groups_path %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,0 +1,32 @@
+<h1>Groups</h1>
+<table class='table'>
+  <thead>
+    <tr>
+      <th>Group Name</th>
+      <th>Members</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @groups.each do |group| %>
+      <tr>
+        <td><%= group.name %></td>
+        <td>
+          <% for user in group.users %>
+            <li>
+              <%= [user.first_name, user.last_name].join(' ') %>
+            </li>
+          <% end %>
+        </td>
+        <td><%= link_to 'Show', group %></td>
+        <td><%= link_to 'Edit', edit_group_path(group) %></td>
+        <td><%= link_to 'Delete', group, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @groups %>
+<br>
+<%= link_to 'New Group', new_group_path %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,0 +1,17 @@
+<h1>New Group</h1>
+<br/>
+<%= form_tag({:action => 'create', :group => @groups}) %>
+  <div class="field">
+    <%= label_tag :"Group name" %>
+    <%= text_field_tag :name%>
+  </div>
+  <br/>
+  <div class="field">
+    <%= label_tag :"Select Users " %>
+    <%= select_tag "users[]", options_for_select(@users.collect{|x| [x.username, x.id]}), {:multiple => :multiple} %>
+  </div>
+  <br/>
+  <div class="actions">
+    <%= submit_tag "Create" %>
+  </div>
+<% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,0 +1,24 @@
+<head>
+  <style>
+    .borderless tr, .borderless td, .borderless th {
+      border: none !important;
+    }
+  </style>
+</head>
+
+<h3>Group Information</h3>
+<p>
+<strong>Name:</strong>
+<%= @group.name %>
+</p>
+
+<p>
+<strong>Groupmembers:</strong>
+<% for user in @group.users %>
+  <li>
+    <%= [user.first_name, user.last_name].join(' ') %>
+  </li>
+<% end %>
+</p>
+
+<%= link_to 'Back', groups_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,6 +58,11 @@
             <li class="nav-item <%= 'active' if params[:controller] == 'annotations' %>">
             <a class="nav-link" href="/annotations">Annotations</a>
             </li>
+            <% if current_user.try(:admin?) %>
+              <li class="dropdown">
+                <a class="nav-link" href="/groups">Group</a>
+              </li>
+            <% end %>
           <% end %>
           <li class="nav-item dropdown <%= 'active' if ['news', 'profile'].include?(params[:controller]) %>">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   resources :patients
   resources :review
   resources :annotations
+  resources :groups
   post '/annotations/new' => 'annotations#new', as: :annotations_new 
 
   namespace :api do

--- a/db/migrate/20180719101344_create_members.rb
+++ b/db/migrate/20180719101344_create_members.rb
@@ -1,0 +1,12 @@
+class CreateMembers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :members do |t|
+      t.integer :group_id
+      t.integer :user_id
+      t.datetime :created_at
+      t.datetime :updated_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180719101411_create_groups.rb
+++ b/db/migrate/20180719101411_create_groups.rb
@@ -1,0 +1,11 @@
+class CreateGroups < ActiveRecord::Migration[5.1]
+  def change
+    create_table :groups do |t|
+      t.string :name
+      t.datetime :created_at
+      t.datetime :updated_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180719102057_add_members_uniqueness_index.rb
+++ b/db/migrate/20180719102057_add_members_uniqueness_index.rb
@@ -1,0 +1,9 @@
+class AddMembersUniquenessIndex < ActiveRecord::Migration[5.1]
+  def self.up
+    add_index :members, [:group_id,:user_id], :unique => true
+  end
+
+  def self.down
+    remove_index :members, [:group_id,:user_id]
+  end
+end

--- a/db/migrate/20180719102057_add_members_uniqueness_index.rb
+++ b/db/migrate/20180719102057_add_members_uniqueness_index.rb
@@ -1,9 +1,9 @@
 class AddMembersUniquenessIndex < ActiveRecord::Migration[5.1]
   def self.up
-    add_index :members, [:group_id,:user_id], :unique => true
+    add_index :members, [:group_id, :user_id], :unique => true
   end
 
   def self.down
-    remove_index :members, [:group_id,:user_id]
+    remove_index :members, [:group_id, :user_id]
   end
 end

--- a/db/migrate/20180801113456_create_groups_patients.rb
+++ b/db/migrate/20180801113456_create_groups_patients.rb
@@ -1,0 +1,12 @@
+class CreateGroupsPatients < ActiveRecord::Migration[5.1]
+  def change
+    create_table :groups_patients do |t|
+      t.integer  :patient_id
+      t.integer  :group_id
+      t.datetime :created_at
+      t.datetime :updated_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180801123615_add_index_fk_groups_patients.rb
+++ b/db/migrate/20180801123615_add_index_fk_groups_patients.rb
@@ -1,0 +1,5 @@
+class AddIndexFkGroupsPatients < ActiveRecord::Migration[5.1]
+  def change
+    add_index :groups_patients, [:group_id, :patient_id], :unique => true
+  end
+end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  created_at: 2018-07-19 12:14:11
+  updated_at: 2018-07-19 12:14:11
+
+two:
+  name: MyString
+  created_at: 2018-07-19 12:14:11
+  updated_at: 2018-07-19 12:14:11

--- a/test/fixtures/groups_patients.yml
+++ b/test/fixtures/groups_patients.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  patient_id: 1
+  group_id: 1
+  created_at: 2018-08-01 13:34:56
+  updated_at: 2018-08-01 13:34:56
+
+two:
+  patient_id: 1
+  group_id: 1
+  created_at: 2018-08-01 13:34:56
+  updated_at: 2018-08-01 13:34:56

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  grp_id: 1
+  user_id: 1
+  created_at: 2018-07-19 12:13:44
+  updated_at: 2018-07-19 12:13:44
+
+two:
+  grp_id: 1
+  user_id: 1
+  created_at: 2018-07-19 12:13:44
+  updated_at: 2018-07-19 12:13:44

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/groups_patient_test.rb
+++ b/test/models/groups_patient_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupsPatientTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MemberTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Adding user group feature.

Group menu option is available only for the admin user. Only the admin can create/edit/delete a group.
Test cases checked:
1) Create a new group: create a new group and add members
2) Delete a group: Deleting also removes all group_member info and groups_patients for that group
3) Edit a group:
    i) Edit the group name 
    ii) add new members
    iii) remove existing members

4) Patient management:
    i)  On group create, add all users_patients to groups_patients.
    ii) Group edit: if new members are added, add the associated patients to groups_patients 
    iii) Group edit: if existing members are removed, remove the associated patients from            groups_patients, These patients do not show up for other group users.
    iv) Patient list: List all group_patients for the user( including from multiple groups), if the user doesn't belong to a group, the list will include only users_patients
    v) If an existing member uploads new patient, add to group_patients

