### PR TITLE
Qc

### DIFF
--- a/app/controllers/api/quality/similarity_job.rb
+++ b/app/controllers/api/quality/similarity_job.rb
@@ -1,0 +1,143 @@
+class SimilarityJob
+
+  JAVA           = '/usr/bin/java'
+  BED_DIR        = '/usr/bin/'
+  RSCRIPT        = '/usr/bin/Rscript'
+  SIMILARITY_DIR = '/opt/genetalk/addons/similarity/'
+  SIMILARITY_JAR = 'VCF2Sim.jar' 
+
+  CONSENSUS_FILE = '/opt/genetalk/data/consensus/consensus.bed'
+  
+  LOG_FILE       = '/opt/genetalk/logs/similarity.log'
+
+  LPATH          = '/opt/genetalk/addons/similarity/LATEX/'
+  LTEMPLATE      = 'f2greport.tex'
+
+
+  DESIRED = {
+               'ti/' => [2.7, 3.6],
+               'Per' => [0.9, 1.0],
+               'var' => [0.016, 0.23],
+               'Non' => [0.8, 1.0],
+               'het' => [1.3, 2.0],
+               'SDS' => [1.0, Float::INFINITY]
+            }
+
+  require 'logger.rb'
+  require 'fileutils.rb'
+  require 'csv.rb'
+
+  #===========================================================================
+  def initialize( vcf_file, output_file = nil )
+    if output_file == nil 
+       @output_file = vcf_file + '_QualityReport.pdf'
+    else
+       @output_file = output_file
+    end
+
+    @vcf_file = vcf_file
+
+    @logger = Logger.new(LOG_FILE, 10, 1024000)
+    @logger.sev_threshold = Logger::INFO
+  end
+
+  #===========================================================================
+  def run()
+    
+    @logger.info "Starting SimilarityJob on #{@vcf_file}"
+
+    throw_error("File not found: #{@vcf_file}") if ! File.file?( @vcf_file )
+
+    vcf_tmpdir = "/tmp/#{File.basename(@vcf_file)}_sim_tmp/"
+    pdf_output = "#{vcf_tmpdir}/QualityReport.pdf"
+    table_file = "#{vcf_tmpdir}/QualityReport_table.txt"
+
+    passed = true
+
+    ok = run_similarity(vcf_tmpdir, pdf_output)
+
+    if ok 
+       passed = check_values( table_file )
+       FileUtils.mv( pdf_output, @output_file, :force => true )
+    else 
+       passed = false 
+       @output_file = nil
+    end
+    
+    @logger.info "Finished SimilarityJob on #{@vcf_file}"
+
+    return passed, @output_file
+
+  end
+
+private
+
+  #===========================================================================
+  def run_similarity(vcf_tmpdir, pdf_output)
+
+    FileUtils.mkdir vcf_tmpdir unless File.directory? vcf_tmpdir
+
+    vcf_tmpfile = "#{vcf_tmpdir}/#{File.basename(@vcf_file)}"
+
+    @logger.info "...Starting BED on #{@vcf_file}"
+    %x@(#{BED_DIR}/intersectBed -a "#{@vcf_file}" -b #{CONSENSUS_FILE} | grep -v "^#" >> "#{vcf_tmpfile}") 2>> #{LOG_FILE} @
+
+    lines = %x@cat "#{vcf_tmpfile}" | wc @.split.first.to_i
+    
+    if lines > 9999
+
+      @logger.info "...Starting Java on #{@vcf_file}"
+
+      err = %x@(cd #{SIMILARITY_DIR}; #{JAVA} -Xmx2g -jar VCF2Sim.jar -d "#{vcf_tmpdir}/" -o similarity.txt 2>&1 >> #{LOG_FILE} )@
+      throw_error( "An error occured while processing your file #{@vcf_file}... #{$?.exitstatus}, #{err}" ) if $? != 0
+
+      @logger.info "...Starting R on #{@vcf_file}"
+      err = %x@(cd #{SIMILARITY_DIR}; #{RSCRIPT} --verbose --vanilla R/MDS.R -i "#{vcf_tmpdir}/similarity.txt" -o "#{pdf_output}" -p "#{LPATH}" -t "#{LTEMPLATE}" 2>&1 >> #{LOG_FILE} )@
+      throw_error( "An error occured while processing your file #{@vcf_file}.... #{$?.exitstatus}, #{err}" ) if $? != 0
+
+      return true
+
+    else
+
+      @logger.info "Abort SimilarityJob on #{@vcf_file}: only #{lines} variants"
+      # raise "Sorry, your VCF file is too short for quality assessment"
+
+      return false
+
+    end
+
+  end
+
+  #===========================================================================
+  def check_values( file )
+    passed = true
+
+    CSV.foreach( file, :col_sep => "\t" ) do |row|
+      target = DESIRED[row[0][0..2]]
+      if target != nil
+        it = row.each
+        it.next 
+        loop do
+          val = it.next.to_f
+          ok = (val > target[0] && val < target[1])
+          passed = false unless ok
+          # puts "#{row[0]}: #{target[0]} > #{val} < #{target[1]} -> #{ok ? "ok" : "NOT OK"}"
+        end # loop
+      end # if
+    end # CSV
+
+    return passed
+
+  end
+
+  #===========================================================================
+  def cleanup()
+  end
+
+  #===========================================================================
+  def throw_error( s )
+    @logger.fatal "Abort SimilarityJob on #{@vcf_file}: #{s}"
+    raise s
+  end
+  
+end

--- a/app/controllers/api/quality/similarity_job.rb
+++ b/app/controllers/api/quality/similarity_job.rb
@@ -1,12 +1,12 @@
 class SimilarityJob
-  LTEMPLATE      = 'f2greport.tex'
+  LTEMPLATE = 'f2greport.tex'
   DESIRED = {
                'ti/' => [2.7, 3.6],
-               'Per' => [0.9, 1.0],
+               'Per' => [0.8, 1.0],
                'var' => [0.016, 0.23],
                'Non' => [0.8, 1.0],
                'het' => [1.3, 2.0],
-               'SDS' => [1.0, Float::INFINITY]
+               'SDS' => [0.0, 1.0]
             }
 
   require 'logger.rb'

--- a/app/controllers/api/vcf_files_controller.rb
+++ b/app/controllers/api/vcf_files_controller.rb
@@ -1,4 +1,5 @@
 class Api::VcfFilesController < Api::BaseController
+  require_relative "quality/similarity_job"
   before_action :authenticate_token
 
   # POST /vcf_files
@@ -57,6 +58,8 @@ class Api::VcfFilesController < Api::BaseController
       end
     end
     vcf.save
+    # QC check
+    passed, output = SimilarityJob.new(f).run()
     add_vcf_to_json(json_path, f)
     user = User.find_by(username: 'FDNA')
     # Check if PEDIA service is already running
@@ -89,7 +92,16 @@ class Api::VcfFilesController < Api::BaseController
     service.job_id = job.id
     service.save
     respond_to do |format|
-      msg = { msg: MSG_VCF_SUCCESS_PEDIA_RUNNING }
+      if passed
+        msg = {msg: MSG_VCF_PASSED_QC }
+      else
+        if output == nil
+          msg = {msg: MSG_VCF_TOO_SHORT }
+        else
+          msg = {msg: MSG_VCF_FAILED_QC }
+        end
+      end
+      #msg = { msg: MSG_VCF_SUCCESS_PEDIA_RUNNING }
       format.json { render plain: msg.to_json,
                     status: 200,
                     content_type: 'application/json'
@@ -114,6 +126,16 @@ class Api::VcfFilesController < Api::BaseController
     end
 
     return valid
+  end
+  
+  # GET /get_QCreport
+  def get_QCreport
+    vcf = params[:vcf]
+    pdf_report = "#{Rails.root}/Data/Received_VcfFiles/#{vcf}/#{vcf}"+ ".vcf_QualityReport.pdf"
+    send_file( pdf_report,
+              :disposition => 'inline',
+              :type => 'application/pdf',
+              :xsend_file => true )
   end
 
   # DELETE /vcf_files/id

--- a/app/controllers/api/vcf_files_controller.rb
+++ b/app/controllers/api/vcf_files_controller.rb
@@ -58,8 +58,6 @@ class Api::VcfFilesController < Api::BaseController
       end
     end
     vcf.save
-    # QC check
-    passed, output = SimilarityJob.new(f).run
     add_vcf_to_json(json_path, f)
     user = User.find_by(username: 'FDNA')
     # Check if PEDIA service is already running
@@ -78,6 +76,8 @@ class Api::VcfFilesController < Api::BaseController
         return
       end
     end
+    # QC check
+    passed, output = SimilarityJob.new(f).run
     status = PediaStatus.find_by(status: PediaStatus::INIT)
     service = PediaService.create(user_id: user.id,
                                   json_file: json_path,

--- a/app/controllers/api/vcf_files_controller.rb
+++ b/app/controllers/api/vcf_files_controller.rb
@@ -93,12 +93,12 @@ class Api::VcfFilesController < Api::BaseController
     service.save
     respond_to do |format|
       if passed
-        msg = {msg: MSG_VCF_PASSED_QC }
+        msg = { msg: MSG_VCF_PASSED_QC }
       else
         if output == nil
-          msg = {msg: MSG_VCF_TOO_SHORT }
+          msg = { msg: MSG_VCF_TOO_SHORT }
         else
-          msg = {msg: MSG_VCF_FAILED_QC }
+          msg = { msg: MSG_VCF_FAILED_QC }
         end
       end
       #msg = { msg: MSG_VCF_SUCCESS_PEDIA_RUNNING }
@@ -133,9 +133,9 @@ class Api::VcfFilesController < Api::BaseController
     vcf = params[:vcf]
     pdf_report = "#{Rails.root}/Data/Received_VcfFiles/#{vcf}/#{vcf}"+ ".vcf_QualityReport.pdf"
     send_file( pdf_report,
-              :disposition => 'inline',
-              :type => 'application/pdf',
-              :xsend_file => true )
+               disposition: 'inline',
+               type: 'application/pdf',
+               xsend_file: true )
   end
 
   # DELETE /vcf_files/id

--- a/app/controllers/api/vcf_files_controller.rb
+++ b/app/controllers/api/vcf_files_controller.rb
@@ -94,11 +94,11 @@ class Api::VcfFilesController < Api::BaseController
     respond_to do |format|
       msg = if passed
               { msg: MSG_VCF_PASSED_QC }
-      elsif output.nil?
-        { msg: MSG_VCF_TOO_SHORT }
-      else
-        { msg: MSG_VCF_FAILED_QC }
-      end
+            elsif output.nil?
+              { msg: MSG_VCF_TOO_SHORT }
+            else
+              { msg: MSG_VCF_FAILED_QC }
+            end
       # msg = { msg: MSG_VCF_SUCCESS_PEDIA_RUNNING }
       format.json { render plain: msg.to_json,
                     status: 200,
@@ -130,11 +130,11 @@ class Api::VcfFilesController < Api::BaseController
     vcf = params[:vcf]
     case_id = params[:case_id]
     pdf_report = "#{Rails.root}/Data/Received_VcfFiles/"\
-                 "#{case_id}/#{vcf}" + ".vcf_QualityReport.pdf"
-    send_file( pdf_report,
+                 "#{case_id}/#{vcf}" + '.vcf_QualityReport.pdf'
+    send_file(pdf_report,
                disposition: 'inline',
                type: 'application/pdf',
-               xsend_file: true )
+               xsend_file: true)
   end
 
   # DELETE /vcf_files/id

--- a/app/controllers/api/vcf_files_controller.rb
+++ b/app/controllers/api/vcf_files_controller.rb
@@ -132,9 +132,9 @@ class Api::VcfFilesController < Api::BaseController
     pdf_report = "#{Rails.root}/Data/Received_VcfFiles/"\
                  "#{case_id}/#{vcf}" + '.vcf_QualityReport.pdf'
     send_file(pdf_report,
-               disposition: 'inline',
-               type: 'application/pdf',
-               xsend_file: true)
+              disposition: 'inline',
+              type: 'application/pdf',
+              xsend_file: true)
   end
 
   # DELETE /vcf_files/id

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -27,3 +27,8 @@ MSG_NO_PEDIA_CASE = 'Case does not exist. Please create a case first to get PEDI
 
 # Log
 API_LOG = File.join("#{Rails.root}", 'log', 'api')
+
+# QC
+MSG_VCF_PASSED_QC = 'VCF file passed QC, report generated and PEDIA running'
+MSG_VCF_TOO_SHORT = 'VCF file too short for QC, no report generated, PEDIA running'
+MSG_VCF_FAILED_QC = 'VCF file failed QC, report generated and PEDIA running'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
     resources :auth ,only: [:create]
     resources :vcf_files, only: [:create, :destroy]
     get '/get_results/' => 'patients#get_results'
+    get '/get_QCreport/' => 'vcf_files#get_QCreport'
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
adding Qc call to Vcf upload API endpoint

Test details:
If testing locally:
1) copy everything in /opt/genetalk/addons/similarity and  /opt/genetalk/data/consensus
2) change the paths in similarity.rb to point to local installations and files
3) Once setup, test vcf upload, the QC tool would now be run before PEDIA is triggered and a report is created if the QC fails or passes
4) The created report is saved in the same folder as the vcf file
5) To get the report generated use GET get_QCreport, parameter: vcf = "vcf file name (without the extension)"
e.g: localhost:3000/api/get_QCreport?vcf=12

NOTE: Additional software required on local set up:
- Java
- R, with packages MASS and shape
- BedTools
- pdfLaTeX 
- The Similarity Tool, i.e. everything in 
 /opt/genetalk/addons/similarity/
 /opt/genetalk/data/consensus/

P.S: On the genetalk server, the tool is already installed and the paths in the similarity.rb correspond to these. We might need to check permissions once deployed