### PR TITLE
Enable loading all variants in VCF

### DIFF
--- a/app/assets/javascripts/show_table.js
+++ b/app/assets/javascripts/show_table.js
@@ -18,7 +18,6 @@ app.controller('MainCtrl',  ['$scope', '$http', '$timeout', '$interval', 'uiGrid
             headerRowHeight: 200,
             showGridFooter: false,
             showColumnFooter: false,
-            rowIdentity: function(row) { return row.id; },
             getRowIdentity: function(row) { return row.id; },
             onRegisterApi: function( gridApi ) {
                 $scope.gridApi = gridApi;
@@ -73,7 +72,7 @@ app.controller('MainCtrl',  ['$scope', '$http', '$timeout', '$interval', 'uiGrid
                 },
                 {
                     displayName: 'HGVS',
-                    name: 'h', 
+                    name: 'h',
                     width:150,
                     cellTemplate: '<div class="ui-grid-cell-contents" title="{{row.entity.h}}"><span>{{COL_FIELD}}</span></div>'
                 },
@@ -149,11 +148,20 @@ app.controller('MainCtrl',  ['$scope', '$http', '$timeout', '$interval', 'uiGrid
             url = 'http://localhost:60151/goto?locus=chr' + pos;
             window.open(url, '_blank');
         }
-
-        url = '/vcf_files/get_var/' + gon.vcf_id 
+        $scope.loadMore = function() {
+            url = '/vcf_files/get_var?id=' + gon.vcf_id +'&all=true'
+            $http.get(url).success(function(data) {
+                $scope.gridOptions.data = data['variants'];
+                $scope.count = data['var_num'];
+                $scope.pediaVar = 'The number of variants in genes with PEDIA score.';
+            });
+            $("#load_button").prop('disabled', true);;
+        };
+        url = '/vcf_files/get_var?id=' + gon.vcf_id
         $http.get(url).success(function(data) {
             $scope.gridOptions.data = data['variants'];
-            $("#var_num").append(data['var_num'])
+            $scope.count = data['var_num'];
+            $scope.pediaVar = 'The number of variants in top 20 PEDIA score genes.';
         });
     }])
 

--- a/app/controllers/api/patients_controller.rb
+++ b/app/controllers/api/patients_controller.rb
@@ -133,16 +133,15 @@ class Api::PatientsController < Api::BaseController
         status = 400
       else
         service = services.last
-        if service.pedia_status.pedia_failed?
-          msg = { msg: service.pedia_status.status }
-          status = 500
-        elsif service.pedia_status.running?
-          msg = { msg: service.pedia_status.status }
-          status = 404
-        elsif service.pedia_status.pedia_complete?
-          result_file_name = (File.join('Data/PEDIA_service/', case_id, service.id.to_s, case_id + '.csv', ))
-          result_file_name_old = (File.join('Data/PEDIA_service/', case_id, case_id + '.csv', ))
-          unless File.exist?(result_file_name) or File.exist?(result_file_name_old)
+        result_file_name = (File.join('Data/PEDIA_service/', case_id, service.id.to_s, case_id + '.csv'))
+        unless File.exist?(result_file_name)
+          if service.pedia_status.workflow_failed?
+            msg = { msg: service.pedia_status.status }
+            status = 500
+          elsif service.pedia_status.workflow_running?
+            msg = { msg: service.pedia_status.status }
+            status = 404
+          else
             msg = { msg: MSG_NO_PEDIA_RESULTS }
             status = 500
           end
@@ -162,11 +161,7 @@ class Api::PatientsController < Api::BaseController
       end
       return
     end
-    if File.exist?(result_file_name)
-      result_file_name = (File.join('Data/PEDIA_service/', case_id, service.id.to_s, case_id + '.csv', ))
-    else
-      result_file_name = (File.join('Data/PEDIA_service/', case_id, case_id + '.csv', ))
-    end
+    result_file_name = (File.join('Data/PEDIA_service/', case_id, service.id.to_s, case_id + '.csv'))
     lines = CSV.open(result_file_name).readlines
     keys = lines.delete lines.first
 

--- a/app/controllers/api/vcf_files_controller.rb
+++ b/app/controllers/api/vcf_files_controller.rb
@@ -64,7 +64,7 @@ class Api::VcfFilesController < Api::BaseController
     unless p_services.empty?
       p_service = p_services.last
       p_status = p_service.pedia_status
-      if p_status.running?
+      if p_status.workflow_running?
         msg = { msg: MSG_PEDIA_RUNNING_TRY_LATER }
         respond_to do |format|
           format.json { render plain: msg.to_json,

--- a/app/controllers/vcf_files_controller.rb
+++ b/app/controllers/vcf_files_controller.rb
@@ -186,18 +186,28 @@ class VcfFilesController < ApplicationController
 
   def get_var
     vcf_id = params[:id]
-    get_pshow_var(vcf_id)
+    all = false
+    all = true if params.has_key?(:all)
+    get_pshow_var(vcf_id, all)
     render :json => ActiveSupport::JSON.encode(@result)
   end
 
-  def get_pshow_var(vcf_id)
+  def get_pshow_var(vcf_id, all=false)
     @vcf_file = VcfFile.find_by_id(vcf_id)
     @p_vcf = @vcf_file.patients_vcf_files.last
     @patient = @vcf_file.patients.take
-    if @patient.pedia_services.count > 0
-      @pedia = @patient.pedia_services.last.pedia.limit(10).order("pedia_score DESC")
+    if all
+      if @patient.pedia_services.count > 0
+        @pedia = @patient.pedia_services.last.pedia.order("pedia_score DESC")
+      else
+        @pedia = @patient.pedia.order("pedia_score DESC")
+      end
     else
-      @pedia = @patient.pedia.limit(10).order("pedia_score DESC")
+      if @patient.pedia_services.count > 0
+        @pedia = @patient.pedia_services.last.pedia.limit(20).order("pedia_score DESC")
+      else
+        @pedia = @patient.pedia.limit(20).order("pedia_score DESC")
+      end
     end
     flash[:alert] = "VCF File not found" and redirect_to vcf_select_path and return if @p_vcf.blank?
 

--- a/app/models/pedia_status.rb
+++ b/app/models/pedia_status.rb
@@ -20,52 +20,46 @@ class PediaStatus < ApplicationRecord
 
   # Use for check if the service encountered unknown exception
   def normal_failed?
-    is_failed = status == PRE_FAILED ||
-                status == WORKFLOW_FAILED ||
-                status == UPLOADING_RESULTS_VCF_FAILED ||
-                status == UPLOADING_RESULTS_SCORE_FAILED
-    return is_failed
+    return status == PRE_FAILED ||
+           status == WORKFLOW_FAILED ||
+           status == UPLOADING_RESULTS_VCF_FAILED ||
+           status == UPLOADING_RESULTS_SCORE_FAILED
   end
 
   def workflow_running?
-    is_running = status == PRE_RUNNING ||
-                 status == WORKFLOW_RUNNING ||
-                 status == INIT
-    return is_running
+    return status == PRE_RUNNING ||
+           status == WORKFLOW_RUNNING ||
+           status == INIT
   end
 
   def workflow_failed?
-    is_failed = status == PRE_FAILED ||
-                status == WORKFLOW_FAILED ||
-                status == UNKNOWN_FAILED
-    return is_failed
+    return status == PRE_FAILED ||
+           status == WORKFLOW_FAILED ||
+           status == UNKNOWN_FAILED
   end
 
   def pedia_failed?
-    is_failed = status == PRE_FAILED ||
-                status == WORKFLOW_FAILED ||
-                status == UPLOADING_RESULTS_VCF_FAILED ||
-                status == UPLOADING_RESULTS_SCORE_FAILED ||
-                status == UNKNOWN_FAILED
-    return is_failed
+    return status == PRE_FAILED ||
+           status == WORKFLOW_FAILED ||
+           status == UPLOADING_RESULTS_VCF_FAILED ||
+           status == UPLOADING_RESULTS_SCORE_FAILED ||
+           status == UNKNOWN_FAILED
   end
 
   # Return True if the workflow is completed
   # If the workflow is completed, then we can return the results via
   # rest api
   def workflow_complete?
-    is_complete = status == WORKFLOW_COMPLETE ||
-                  status == UPLOADING_RESULTS_SCORE_RUNNING ||
-                  status == UPLOADING_RESULTS_SCORE_COMPLETE ||
-                  status == UPLOADING_RESULTS_VCF_RUNNING ||
-                  status == UPLOADING_RESULTS_VCF_COMPLETE ||
-                  status == COMPLETE
-    return is_complete
+    return status == WORKFLOW_COMPLETE ||
+           status == UPLOADING_RESULTS_SCORE_RUNNING ||
+           status == UPLOADING_RESULTS_SCORE_COMPLETE ||
+           status == UPLOADING_RESULTS_VCF_RUNNING ||
+           status == UPLOADING_RESULTS_VCF_COMPLETE ||
+           status == COMPLETE
   end
 
   # Check if the whole pedia service is complete
   def pedia_complete?
-    is_complete = status == COMPLETE
-    return is_complete
+    return status == COMPLETE
   end
 end

--- a/app/models/pedia_status.rb
+++ b/app/models/pedia_status.rb
@@ -9,28 +9,61 @@ class PediaStatus < ApplicationRecord
   WORKFLOW_RUNNING = 'Workflow running'.freeze
   WORKFLOW_FAILED = 'Workflow failed'.freeze
   COMPLETE = 'Complete'.freeze
+  WORKFLOW_COMPLETE = 'Workflow complete'.freeze
+  UPLOADING_RESULTS_SCORE_RUNNING = 'Uploading score running'.freeze
+  UPLOADING_RESULTS_SCORE_COMPLETE = 'Uploading score complete'.freeze
+  UPLOADING_RESULTS_SCORE_FAILED = 'Uploading score failed'.freeze
+  UPLOADING_RESULTS_VCF_RUNNING = 'Uploading VCF running'.freeze
+  UPLOADING_RESULTS_VCF_COMPLETE = 'Uploading VCF complete'.freeze
+  UPLOADING_RESULTS_VCF_FAILED = 'Uploading VCF failed'.freeze
   UNKNOWN_FAILED = 'PEDIA failed. Unknown issue.'.freeze
 
   # Use for check if the service encountered unknown exception
   def normal_failed?
-    is_failed = status == PRE_FAILED || status == WORKFLOW_FAILED
+    is_failed = status == PRE_FAILED ||
+                status == WORKFLOW_FAILED ||
+                status == UPLOADING_RESULTS_VCF_FAILED ||
+                status == UPLOADING_RESULTS_SCORE_FAILED
     return is_failed
   end
 
-  def running?
+  def workflow_running?
     is_running = status == PRE_RUNNING ||
                  status == WORKFLOW_RUNNING ||
                  status == INIT
     return is_running
   end
 
-  def pedia_failed?
+  def workflow_failed?
     is_failed = status == PRE_FAILED ||
                 status == WORKFLOW_FAILED ||
                 status == UNKNOWN_FAILED
     return is_failed
   end
 
+  def pedia_failed?
+    is_failed = status == PRE_FAILED ||
+                status == WORKFLOW_FAILED ||
+                status == UPLOADING_RESULTS_VCF_FAILED ||
+                status == UPLOADING_RESULTS_SCORE_FAILED ||
+                status == UNKNOWN_FAILED
+    return is_failed
+  end
+
+  # Return True if the workflow is completed
+  # If the workflow is completed, then we can return the results via
+  # rest api
+  def workflow_complete?
+    is_complete = status == WORKFLOW_COMPLETE ||
+                  status == UPLOADING_RESULTS_SCORE_RUNNING ||
+                  status == UPLOADING_RESULTS_SCORE_COMPLETE ||
+                  status == UPLOADING_RESULTS_VCF_RUNNING ||
+                  status == UPLOADING_RESULTS_VCF_COMPLETE ||
+                  status == COMPLETE
+    return is_complete
+  end
+
+  # Check if the whole pedia service is complete
   def pedia_complete?
     is_complete = status == COMPLETE
     return is_complete

--- a/app/views/vcf_files/show.html.erb
+++ b/app/views/vcf_files/show.html.erb
@@ -39,18 +39,11 @@ ready = function() {
     $('#showhidehposettingsoff').toggle();
     $('#showhidehposettingson').toggle();
   });
-  /*
-  var updateFilterBar = function (){ 
-    $.get( '/vcf_files/get_job_status/18', function (result) {
-      filterTimer = window.setTimeout( function(){ updateFilterBar(); }, 1000);  
-    });
-  };
-  var filterTimer = window.setTimeout( function(){ updateFilterBar(); }, 1000);  */
 };
 $(document).ready(ready);
 
 $(document).on('page:load', ready);
-</script>    
+</script>
 
 <style type="text/css">
 .grid {
@@ -60,21 +53,29 @@ $(document).on('page:load', ready);
 </style>
 <% end %>
 <%= heading_block 'VCF Viewer' do %>
-
-    <h5>File: <%= @vcf.name%></h5>
-    <h5 id='var_num'>Variants: </h5>
-<div ng-app="app">
-  <div ng-controller="MainCtrl">
+  <h5>File: <%= @vcf.name%></h5>
+  <div ng-app="app">
+    <div ng-controller="MainCtrl">
+      <p id='var_num'>
+        <font size='4'>Variants: {{count}}</font size>
+        <a id='pedia_var_str' title='{{pediaVar}}'>&#9432;</a>
+      </p>
+		  <button id="load_button" type="button" ng-click="loadMore()" class="btn btn-sm btn-success">
+        Load all variants
+		  </button>
+      <a title='Please note, it might takes a while to load all variants!'>&#9432;</a>
+      <br>
+      <br>
       <div id="grid1" ui-grid="gridOptions" class="grid">
-      <div class="well grid-loading" ng-show="grid.rows.length == 0">
-        <i class="fa fa-spin fa-spinner"></i>
-          <strong>Data Loading...</strong>
+        <div class="well grid-loading" ng-show="grid.rows.length == 0">
+          <i class="fa fa-spin fa-spinner"></i>
+            <strong>Data Loading...</strong>
+        </div>
       </div>
     </div>
   </div>
-</div>
-<br>
-<br>
+  <br>
+  <br>
 <%= link_to 'Back', :back %>
 <br>
 <br>

--- a/app/views/vcf_files/show.html.erb
+++ b/app/views/vcf_files/show.html.erb
@@ -69,14 +69,14 @@ $(document).on('page:load', ready);
       <div id="grid1" ui-grid="gridOptions" class="grid">
         <div class="well grid-loading" ng-show="grid.rows.length == 0">
           <i class="fa fa-spin fa-spinner"></i>
-            <strong>Data Loading...</strong>
+          <strong>Data Loading...</strong>
         </div>
       </div>
     </div>
   </div>
   <br>
   <br>
-<%= link_to 'Back', :back %>
-<br>
-<br>
+  <%= link_to 'Back', :back %>
+  <br>
+  <br>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   end
   put 'activate/:id', to: 'users#activate', as: :activate_user
   put 'deactivate/:id', to: 'users#deactivate', as: :deactivate_user
-  get 'vcf_files/get_var/:id', to: 'vcf_files#get_var', as: :vcf_files_get_var
+  get 'vcf_files/get_var', to: 'vcf_files#get_var', as: :vcf_files_get_var
   get :get_review, :controller => :review
   get '/get_img/:filename' => 'patients#get_img', :constraints => { :filename => /.*/ }
   get 'patients/download_vcf'

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -185,6 +185,13 @@ namespace :bootstrap do
     PediaStatus.find_or_create_by(status: PediaStatus::PRE_FAILED)
     PediaStatus.find_or_create_by(status: PediaStatus::WORKFLOW_RUNNING)
     PediaStatus.find_or_create_by(status: PediaStatus::WORKFLOW_FAILED)
+    PediaStatus.find_or_create_by(status: PediaStatus::WORKFLOW_COMPLETE)
+    PediaStatus.find_or_create_by(status: PediaStatus::UPLOADING_RESULTS_SCORE_RUNNING)
+    PediaStatus.find_or_create_by(status: PediaStatus::UPLOADING_RESULTS_SCORE_COMPLETE)
+    PediaStatus.find_or_create_by(status: PediaStatus::UPLOADING_RESULTS_SCORE_FAILED)
+    PediaStatus.find_or_create_by(status: PediaStatus::UPLOADING_RESULTS_VCF_RUNNING)
+    PediaStatus.find_or_create_by(status: PediaStatus::UPLOADING_RESULTS_VCF_COMPLETE)
+    PediaStatus.find_or_create_by(status: PediaStatus::UPLOADING_RESULTS_VCF_FAILED)
     PediaStatus.find_or_create_by(status: PediaStatus::COMPLETE)
     PediaStatus.find_or_create_by(status: PediaStatus::UNKNOWN_FAILED)
   end

--- a/lib/tasks/move_pedia_service.rake
+++ b/lib/tasks/move_pedia_service.rake
@@ -1,6 +1,6 @@
 require 'csv'
 namespace :pedia do
-  desc "move resuls file in pedia_service folder"
+  desc 'move resuls file in pedia_service folder'
   task :move_results => :environment do
     status = PediaStatus.find_by_status('Complete')
     services = status.pedia_services

--- a/lib/tasks/move_pedia_service.rake
+++ b/lib/tasks/move_pedia_service.rake
@@ -1,0 +1,30 @@
+require 'csv'
+namespace :pedia do
+  desc "move resuls file in pedia_service folder"
+  task :move_results => :environment do
+    status = PediaStatus.find_by_status('Complete')
+    services = status.pedia_services
+    service_path = 'Data/PEDIA_service/'
+    services.each do |service|
+      case_id = service.patient.case_id
+      result_path = File.join(service_path, case_id.to_s, service.id.to_s, case_id.to_s + '.csv')
+      unless File.exist?(result_path)
+        msg = ['Result file not in pedia service dir:',
+               case_id.to_s,
+               service.id.to_s].join(' ')
+        puts msg
+        old_result_path = File.join(service_path, case_id.to_s, case_id.to_s + '.csv')
+        if File.exist?(old_result_path)
+          path = File.join(service_path, case_id.to_s, service.id.to_s)
+          FileUtils.mkdir_p(path)
+          FileUtils.cp(old_result_path, result_path)
+        else
+          msg = ['Fatal: old result file not in pedia service dir:',
+                 case_id.to_s,
+                 service.id.to_s].join(' ')
+          puts msg
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We show the variants in top 20 PEDIA score genes when we enter VCF
viewer. By pressing the 'Load more variants' button, we load all
the variants in the genes with PEDIA scores.

We added uploading pedia results and vcf in previous pull request.
However, we didn't add status for these two event. If the uploading
takes longer than 30 mins, F2G might got timeout because they can't
receive results in maybe 40 mins.

Here we add the following status.
UPLOADING_RESULTS_VCF_RUNNING
UPLOADING_RESULTS_VCF_COMPLETE
UPLOADING_RESULTS_VCF_FAILED
UPLOADING_RESULTS_SCORE_RUNNING
UPLOADING_RESULTS_SCORE_COMPLETE
UPLOADING_RESULTS_SCORE_FAILED
WORKFLOW_COMPLETE
Once the workflow is complete, we can get the results via api even
the uploading haven't finished.

For this patch, please run rake bootstrap:defult_pedia_status to
update the pedia status.

If you already have results for some cases, please run
rake pedia:move_results. Then the results will move to
Data/PEDIA_service/case_id/pedia_service_id/
