### PR TITLE
Enable VCF quality report

### DIFF
--- a/app/controllers/api/quality/similarity_job.rb
+++ b/app/controllers/api/quality/similarity_job.rb
@@ -36,7 +36,7 @@ class SimilarityJob
       @BED_DIR        = '/usr/bin/'
       @RSCRIPT        = '/usr/bin/Rscript'
       @SIMILARITY_DIR = '/opt/genetalk/addons/similarity/'
-      @SIMILARITY_JAR = 'VCF2Sim.jar' 
+      @SIMILARITY_JAR = '/opt/genetalk/addons/similarity/VCF2Sim.jar'
       @CONSENSUS_FILE = '/opt/genetalk/data/consensus/consensus.bed'
       @LOG_FILE       = '/opt/genetalk/logs/similarity.log'
       @LPATH          = '/opt/genetalk/addons/similarity/LATEX/'
@@ -47,14 +47,14 @@ class SimilarityJob
       @RSCRIPT        = path['RSCRIPT']
       @SIMILARITY_DIR = path['SIMILARITY_DIR']
       @SIMILARITY_JAR = path['SIMILARITY_JAR']
-      @CONSENSUS_FILE = path['CONSENSUS_FILE'] 
+      @CONSENSUS_FILE = path['CONSENSUS_FILE']
       @LOG_FILE       = path['LOG_FILE']
       @LPATH          = path['LPATH']
-      end
     end
+  end
   #===========================================================================
   def run()
-    
+
     @logger.info "Starting SimilarityJob on #{@vcf_file}"
 
     throw_error("File not found: #{@vcf_file}") if ! File.file?( @vcf_file )
@@ -67,14 +67,14 @@ class SimilarityJob
 
     ok = run_similarity(vcf_tmpdir, pdf_output)
 
-    if ok 
+    if ok
        passed = check_values( table_file )
        FileUtils.mv( pdf_output, @output_file, :force => true )
-    else 
-       passed = false 
+    else
+       passed = false
        @output_file = nil
     end
-    
+
     @logger.info "Finished SimilarityJob on #{@vcf_file}"
 
     return passed, @output_file

--- a/app/models/vcf_file.rb
+++ b/app/models/vcf_file.rb
@@ -219,7 +219,6 @@ class VcfFile < ActiveRecord::Base
         chrom, pos, ident, ref, alt, qual, filter, info, format, *gt = line.split("\t");
         chrom_num = VcfTools.chrom_to_i(chrom)
 
-        Delayed::Worker.logger.debug("chrome")
         #Skip the variant which is not in chr1-22 X,Y
         next if chrom_num == 0
 

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -172,17 +172,19 @@
     <% unless @pedia_service.nil? %>
       <% if @pedia_service.pedia_status.pedia_complete? %>
         <% vcf = @pedia_service.vcf_file %>
-        <tr>
-          <td><%= vcf.file_name unless vcf.file_name.nil? %></td>
-          <td><%= vcf.user.username unless vcf.user.username.nil? %></td>
-          <td><%= vcf.updated_at %></td>
-          <td>
-            annotated VCF
-            <a title='This file is annotated and the variants not in exon region are filtered out!'>&#9432;</a>
-          </td>
-          <td><%= link_to 'Download VCF', patients_download_vcf_url(:name => vcf.full_path) %></td>
-          <td><%= link_to 'Delete', vcf, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-        </tr>
+        <% unless vcf.nil? %>
+          <tr>
+            <td><%= vcf.name unless vcf.name.nil? %></td>
+            <td><%= vcf.user.username unless vcf.user.username.nil? %></td>
+            <td><%= vcf.updated_at %></td>
+            <td>
+              annotated VCF
+              <a title='This file is annotated and the variants not in exon region are filtered out!'>&#9432;</a>
+            </td>
+            <td><%= link_to 'Download VCF', patients_download_vcf_url(:name => vcf.full_path) %></td>
+            <td><%= link_to 'Delete', vcf, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          </tr>
+        <% end %>
       <% end %>
     <% end %>
   </tbody>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -155,21 +155,21 @@
   </thead>
 
   <tbody>
-    <% vcf = @patient.uploaded_vcf_files.last %>
-    <% unless vcf.nil? %>
-      <tr>
-        <td><%= vcf.file_name unless vcf.file_name.nil? %></td>
-        <td><%= vcf.user.username unless vcf.user.username.nil? %></td>
-        <td><%= vcf.updated_at %></td>
-        <td>
-          original VCF
-          <a title='This file is uploaded by user.'>&#9432;</a>
-        </td>
-        <td><%= link_to 'Download VCF', patients_download_vcf_url(:name => vcf.full_path) %></td>
-        <td><%= link_to 'Delete', vcf, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      </tr>
-    <% end %>
     <% unless @pedia_service.nil? %>
+      <% vcf = @pedia_service.uploaded_vcf_file %>
+      <% unless vcf.nil? %>
+        <tr>
+          <td><%= vcf.file_name unless vcf.file_name.nil? %></td>
+          <td><%= vcf.user.username unless vcf.user.username.nil? %></td>
+          <td><%= vcf.updated_at %></td>
+          <td>
+            original VCF
+            <a title='This file is uploaded by user.'>&#9432;</a>
+          </td>
+          <td><%= link_to 'Download VCF', patients_download_vcf_url(:name => vcf.full_path) %></td>
+          <td><%= link_to 'Delete', vcf, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        </tr>
+      <% end %>
       <% if @pedia_service.pedia_status.pedia_complete? %>
         <% vcf = @pedia_service.vcf_file %>
         <% unless vcf.nil? %>

--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -37,7 +37,7 @@
         <b>Disorder:</b>
         <% search.get_selected_disorders.each do |disorder|%>
           <tr>
-            <td><%= disorder.disorder.disorder_id %></td>
+            <td><%= disorder.disorder.omim_id %></td>
             <td><%= disorder.disorder.disorder_name %></td>
           </tr>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,14 +34,14 @@ Rails.application.routes.draw do
   resources :review
   resources :annotations
   resources :uploaded_vcf_files
-  post '/annotations/new' => 'annotations#new', as: :annotations_new 
+  post '/annotations/new' => 'annotations#new', as: :annotations_new
 
   namespace :api do
     resources :patients, only: [:create, :destroy]
     resources :auth ,only: [:create]
     resources :vcf_files, only: [:create, :destroy]
     get '/get_results/' => 'patients#get_results'
-    get '/get_QCreport/' => 'vcf_files#get_QCreport'
+    get '/get_quality_report/' => 'vcf_files#get_quality_report'
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20181223231611_change_json_file_null_true_pedia_service.rb
+++ b/db/migrate/20181223231611_change_json_file_null_true_pedia_service.rb
@@ -1,0 +1,9 @@
+class ChangeJsonFileNullTruePediaService < ActiveRecord::Migration[5.1]
+  def up
+    change_column :pedia_services, :json_file, :string, :null => true
+  end
+
+  def down
+    change_column :pedia_services, :json_file, :string, :null => false
+  end
+end

--- a/db/migrate/20190102141231_add_quality_report_uploaded_vcf.rb
+++ b/db/migrate/20190102141231_add_quality_report_uploaded_vcf.rb
@@ -1,0 +1,6 @@
+class AddQualityReportUploadedVcf < ActiveRecord::Migration[5.1]
+  def change
+    add_column :uploaded_vcf_files, :quality_report_path, :string
+    add_column :uploaded_vcf_files, :quality_result, :string
+  end
+end


### PR DESCRIPTION
Enable VCF quality report:
We run the quality report before triggering PEDIA service.
The result and output are saved in UploadedVcfFile and the
file location is in Data/PEDIA_service/case_id/service_id/.

To get quality report, use get_quality_report?case_id=case_id.